### PR TITLE
config: Adding .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false


### PR DESCRIPTION
I added .editorconfig to maintain code standardization independent of the code editor.

```
root = true // Marks this file as the root of the repository

[*]
indent_style = space // Use spaces instead of tabs
indent_size = 2 // Size of indentation: 2 spaces
end_of_line = lf // Line ending style: LF
charset = utf-8 // Character encoding: UTF-8
trim_trailing_whitespace = false // Do not trim trailing whitespace
insert_final_newline = false // Do not insert a final newline at the end of files
```
